### PR TITLE
Add healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
 FROM mariadb:10.5
 
 COPY ./docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d
+
+HEALTHCHECK --interval=10s --timeout=5s --retries=6 \
+  CMD (echo 'use scope_waveforms' | mysql -u scope_rw -ppassword) || exit 1


### PR DESCRIPTION
This adds a healthcheck that can be used to order container startup in docker compose files or with docker compose -d --wait to make sure that automation steps don't continue until the containers are fully initialized.