### PR TITLE
Use row compression on array data

### DIFF
--- a/docker-entrypoint-initdb.d/01-create-db.sql
+++ b/docker-entrypoint-initdb.d/01-create-db.sql
@@ -47,7 +47,7 @@ CREATE TABLE waveform_adata
     FOREIGN KEY (wid) REFERENCES waveform (wid)
         ON DELETE CASCADE
         ON UPDATE CASCADE
-);
+) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 CREATE INDEX wad_name_index on waveform_adata (name);
 
 CREATE TABLE waveform_sdata


### PR DESCRIPTION
Enable row compression on the waveform_adata.  Initial testing in docker suggests 2:1 compression ratio.